### PR TITLE
Fix broken URLs

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,11 +1,11 @@
 [
   {
     "package": "bspm",
-    "url": "https://enchufa2.github.io/bspm/"
+    "url": "https://github.com/cran4linux/bspm"
   },
   {
     "package": "rspm",
-    "url": "https://enchufa2.github.io/rspm/"
+    "url": "https://github.com/cran4linux/rspm"
   },
   {
     "package": "bmetr",


### PR DESCRIPTION
By the way, it may be easier to just delete this repo with the custom `packages.json` registry because all your packages are on CRAN and therefore automatically ingested from their owner git orgs, and will be auto cross referenced on https://enchufa2.r-universe.dev/. So there is no need to maintain a custom list here. 